### PR TITLE
Remove unnecessary `loadViewIfNeeded` on Basic UT

### DIFF
--- a/TPWorkshopUnitTest/3-Advanced/AdvancedNetworkProvider.swift
+++ b/TPWorkshopUnitTest/3-Advanced/AdvancedNetworkProvider.swift
@@ -8,23 +8,23 @@
 import Foundation
 
 protocol AdvancedNetworkProvider {
-    func fetchProduct() -> NetworkResult<ProductResult>
+    func fetchProduct(onComplete: @escaping (NetworkResult<ProductResult>) -> Void)
 }
 
 struct AdvancedUseCase: AdvancedNetworkProvider {
-    func fetchProduct() -> NetworkResult<ProductResult> {
+    func fetchProduct(onComplete: @escaping (NetworkResult<ProductResult>) -> Void) {
         guard let url = Bundle.main.path(forResource: "ProductData", ofType: "json") else {
-            return .failed("URL Not found")
+            return onComplete(.failed("URL Not found"))
         }
         
         if let data = try? Data(contentsOf: URL(fileURLWithPath: url), options: .mappedIfSafe) {
             if let result = try? JSONDecoder().decode(ProductResult.self, from: data) {
-                return .success(result)
+                return onComplete(.success(result))
             } else {
-                return .failed("Failed when decoding")
+                return onComplete(.failed("Failed when decoding"))
             }
         } else {
-            return .failed("Failed converting to data")
+            return onComplete(.failed("Failed converting to data"))
         }
     }
 }

--- a/TPWorkshopUnitTestTests/1-Basic-WithoutPattern.swift
+++ b/TPWorkshopUnitTestTests/1-Basic-WithoutPattern.swift
@@ -13,7 +13,6 @@ class __Basic_WithoutPattern: XCTestCase {
     
     override func setUp() {
         vc = FirstBasicViewController(nibName: "FirstBasicViewController", bundle: nil)
-        vc.loadViewIfNeeded()
     }
     
     override func tearDown() {

--- a/TPWorkshopUnitTestTests/1-Basic-WithoutPattern.swift
+++ b/TPWorkshopUnitTestTests/1-Basic-WithoutPattern.swift
@@ -13,6 +13,7 @@ class __Basic_WithoutPattern: XCTestCase {
     
     override func setUp() {
         vc = FirstBasicViewController(nibName: "FirstBasicViewController", bundle: nil)
+        vc.loadViewIfNeeded()
     }
     
     override func tearDown() {

--- a/TPWorkshopUnitTestTests/3-MockData.swift
+++ b/TPWorkshopUnitTestTests/3-MockData.swift
@@ -23,15 +23,15 @@ struct MockProductData {
 }
 
 struct MockPositiveWorkshopProvider: AdvancedNetworkProvider {
-    func fetchProduct() -> NetworkResult<ProductResult> {
+    func fetchProduct(onComplete: @escaping (NetworkResult<ProductResult>) -> Void) {
         let result = MockProductData.generateProductResult()
         
-        return .success(result)
+        onComplete(.success(result))
     }
 }
 
 struct MockNegativeWorkshopProvider: AdvancedNetworkProvider {
-    func fetchProduct() -> NetworkResult<ProductResult> {
-        return .failed("failed")
+    func fetchProduct(onComplete: @escaping (NetworkResult<ProductResult>) -> Void) {
+        onComplete(.failed("failed"))
     }
 }


### PR DESCRIPTION
- Remove `loadViewIfNeeded` from Basic UT
- Update `AdvanceNetworkProvider` fetch product implementation. The function will receive closure as param in order to keep the consistensy with `PracticeNetworkProvider` and give impression of async job


| Test Result | UI |
|------|-------|
|<img width="408" alt="Screen Shot 2021-12-08 at 16 14 18" src="https://user-images.githubusercontent.com/50827665/145181456-344abeda-1713-45df-8792-12fd238cb5f2.png">|![Simulator Screen Shot - iPhone 13 mini - 2021-12-08 at 16 07 19](https://user-images.githubusercontent.com/50827665/145181108-84e387b7-4d8f-49ff-8018-7d828cbb8b52.png)|